### PR TITLE
Remove hash from device ID to avoid ValueError: Publish topic cannot contain wildcards.

### DIFF
--- a/findmy/__init__.py
+++ b/findmy/__init__.py
@@ -125,7 +125,7 @@ def send_data_items(force_sync):
 
         device_updates[device_name] = (lastUpdate, location_name)
 
-        device_id = get_device_id(device_name)
+        device_id = re.sub('[^0-9a-zA-Z_]+', '', get_device_id(device_name))
         device_topic = f"homeassistant/device_tracker/{device_id}/"
         device_config = {
             "unique_id": device_id,
@@ -179,7 +179,7 @@ def send_data_devices(force_sync):
 
         device_updates[device_name] = (lastUpdate, location_name)
 
-        device_id = get_device_id(device_name)
+        device_id = re.sub('[^0-9a-zA-Z_]+', '', get_device_id(device_name))
         device_topic = f"homeassistant/device_tracker/{device_id}/"
         device_config = {
             "unique_id": device_id,


### PR DESCRIPTION
This change fixes a crash due to one of my devices having a '#' character in the ID: **nathan's_airpods_pro_#2**

```
% ./start.sh
Traceback (most recent call last):
  File "/Users/ndbroadbent/Library/Python/3.9/bin/findmy", line 8, in <module>
    sys.exit(main())
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/findmy/__init__.py", line 320, in main
    scan_cache(privacy, force_sync)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/findmy/__init__.py", line 220, in scan_cache
    send_data_devices(force_sync)
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/findmy/__init__.py", line 209, in send_data_devices
    client.publish(device_topic + "config", json.dumps(device_config))
  File "/Users/ndbroadbent/Library/Python/3.9/lib/python/site-packages/paho/mqtt/client.py", line 1233, in publish
    raise ValueError('Publish topic cannot contain wildcards.')
ValueError: Publish topic cannot contain wildcards.
```

Thanks for the great script, this was my only issue with it!