### PR TITLE
Remove ilegal characters from device ID

### DIFF
--- a/findmy/__init__.py
+++ b/findmy/__init__.py
@@ -82,7 +82,8 @@ def load_data(data_file):
 
 
 def get_device_id(name):
-    return unidecode(re.sub(r'[\s-]', '_', name).lower())
+    name = unidecode(re.sub(r'[\s-]', '_', name).lower())
+    return re.sub(r'[^a-zA-Z0-9_-]', '', name)
 
 
 def get_source_type(apple_position_type):


### PR DESCRIPTION
Added a simple regex to remove any characters which does not match MQTT discovery message requirements "[a-zA-Z0-9_-]" 
Fault message: 

2023-10-29 19:56:13.436 WARNING (MainThread) [homeassistant.components.mqtt.discovery] Received message on illegal discovery topic 'homeassistant/device_tracker/****'s_mac_mini/config'. The topic contains not allowed characters. For more information see https://www.home-assistant.io/docs/mqtt/discovery/#discovery-topic
