### PR TITLE
Fix/invalid device id

### DIFF
--- a/.github/MIGRATION_GUIDE/1.0.2.md
+++ b/.github/MIGRATION_GUIDE/1.0.2.md
@@ -1,4 +1,4 @@
-# Migrating to 1.0.2
+# Migrating from < v1.x.x
 
 Since 1.0.X brought breaking changes, here is a small guide that should help you to 
 migrate your setup with as little effort as possible.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # home-assistant-findmy
 A python script that reads local FindMy cache files to publish device locations and metadata (including those of AirTags, AirPods, Apple Watches, iPhones) to Home Assistant via MQTT.
 
-[Migration to v1.0.2](https://github.com/muehlt/home-assistant-findmy/tree/main/.github/MIGRATION_GUIDE/1.0.2.md) • 
+[Migration from < v1.x.x](https://github.com/muehlt/home-assistant-findmy/tree/main/.github/MIGRATION_GUIDE/1.0.2.md) • 
 [Support this project](https://buymeacoffee.com/muehlt)
 
 
@@ -19,8 +19,7 @@ data to MQTT to be used in Home Assistant. It uses auto discovery so no
 further entity configuration is needed in Home Assistant. Consult the 
 documentation on how to set up an MQTT broker for Home Assistant. The script
 needs to be executed on macOS with a running FindMy installation. It must 
-be executed as root and in a terminal with full disk access to be able 
-to read the cache files.
+be executed in a terminal with full disk access to be able to read the cache files.
 
 ## Supports
 - Devices (iPhones, iPads, MacBooks, AirPods, Apple Watches, ...)
@@ -29,7 +28,7 @@ to read the cache files.
 
 ## How to use
 
-[Migration to v1.0.2](https://github.com/muehlt/home-assistant-findmy/tree/main/.github/MIGRATION_GUIDE/1.0.2.md)
+[Migration from < v1.x.x](https://github.com/muehlt/home-assistant-findmy/tree/main/.github/MIGRATION_GUIDE/1.0.2.md)
 
 ### Basic installation
 
@@ -104,6 +103,13 @@ e.g. `findmy -l /path/to/known_locations.json`
 > **Warning**: For security reasons, it's advised not to set the password using the `--password` parameter, except in rare test cases. Always prefer setting it via the environment variable.
 
 ## Versions
+
+### 1.1.0
+In very rare occasions, or if you have changed the code before, this version might
+lead to changed device IDs being propagated to your Home Assistant instance.
+- Fix invalid device IDs by removing special characters
+- Cleanup of device IDs client side for consistency
+- Minor improvements
 
 ### 1.0.X - Breaking changes
 - Configuration is now done solely via environment variables and a JSON file for known locations

--- a/findmy/__init__.py
+++ b/findmy/__init__.py
@@ -8,16 +8,16 @@
 #                                                             -'                  `-'
 # made with ♡ by muehlt
 # github.com/muehlt
-# version 1.0.2
+# version 1.1.0
 #
 # DESCRIPTION:  This python script reads the FindMy cache files and publishes the location
 #               data to MQTT to be used in Home Assistant. It uses auto discovery so no
 #               further entity configuration is needed in Home Assistant. Consult the
 #               documentation on how to set up an MQTT broker for Home Assistant. The script
 #               needs to be executed on macOS with a running FindMy installation. It needs
-#               to be executed as root and in a terminal with full disk access to be able
-#               to read the cache files. The script must be configured using the variables
-#               below and the mqtt client password as environment variable.
+#               to be executed in a terminal with full disk access to be able to read the
+#               cache files. The script must be configured using the variables below and the
+#               mqtt client password as environment variable.
 #
 # DISCLAIMER:   This script is provided as-is, without any warranty. Use at your own risk.
 #               This code is not tested and should only be used for experimental purposes.
@@ -119,13 +119,14 @@ def send_data_items(force_sync):
             location_name = get_location_name((latitude, longitude))
             lastUpdate = device['location']['timeStamp']
 
-        device_update = device_updates.get(device_name)
+        device_id = re.sub('[_]+', '_', re.sub('[^0-9a-zA-Z_-]+', '', get_device_id(device_name)))
+        updates_identifier = f"{device_name} ({device_id})"
+
+        device_update = device_updates.get(updates_identifier)
         if not force_sync and device_update and len(device_update) > 0 and device_update[0] == lastUpdate:
             continue
 
-        device_updates[device_name] = (lastUpdate, location_name)
-
-        device_id = re.sub('[^0-9a-zA-Z_]+', '', get_device_id(device_name))
+        device_updates[updates_identifier] = (lastUpdate, location_name)
         device_topic = f"homeassistant/device_tracker/{device_id}/"
         device_config = {
             "unique_id": device_id,
@@ -173,13 +174,14 @@ def send_data_devices(force_sync):
             location_name = get_location_name((latitude, longitude))
             lastUpdate = device['location']['timeStamp']
 
-        device_update = device_updates.get(device_name)
+        device_id = re.sub('[_]+', '_', re.sub('[^0-9a-zA-Z_-]+', '', get_device_id(device_name)))
+        updates_identifier = f"{device_name} ({device_id})"
+
+        device_update = device_updates.get(updates_identifier)
         if not force_sync and device_update and len(device_update) > 0 and device_update[0] == lastUpdate:
             continue
 
-        device_updates[device_name] = (lastUpdate, location_name)
-
-        device_id = re.sub('[^0-9a-zA-Z_]+', '', get_device_id(device_name))
+        device_updates[updates_identifier] = (lastUpdate, location_name)
         device_topic = f"homeassistant/device_tracker/{device_id}/"
         device_config = {
             "unique_id": device_id,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name="home-assistant-findmy",
-    version="1.0.2",
+    version="1.1.0",
     author="muehlt",
     author_email="thomas@savory.at",
     description="A python script that reads local FindMy cache files to broadcast device locations (including those of AirTags, AirPods, Apple Watches, iPhones) to Home Assistant via MQTT.",


### PR DESCRIPTION
Resolves issues related to special characters in the propagated device ID and performs a clean-up client-side to make the local device ID consistent with Home Assistant.